### PR TITLE
Use `lib.systems.flakeExposed` instead of `lib.systems.supported.hydra`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
   outputs = inputs@{ self, nixpkgs }:
     let
       # Support the same list of systems as upstream.
-      systems = lib.systems.supported.hydra;
+      systems = lib.systems.flakeExposed;
 
       lib = nixpkgs.lib;
 


### PR DESCRIPTION
Fails to evaluate otherwise:
```
error: 2022-05-23: Use lib.systems.flakeExposed instead of lib.systems.supported.hydra, as lib.systems.supported has been removed
```

See https://github.com/NixOS/nixpkgs/pull/168316