### PR TITLE
ci: introduce self-hosted runner

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,22 @@
+name: Nix
+on:
+  push:
+    branches:
+      - main
+      - nixos-unstable
+      - nixpkgs-unstable
+  pull_request:
+  workflow_dispatch:
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+          - [X64, Linux, nix]
+          # Dreaming
+          # - [ARM64, Linux, nix]
+          # - [ARM64, Darwin, nix]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - run: nix-build ci.nix --keep-going

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ expanding to provide a wider set of features.
 
 ### Binary cache
 
-The CI is pushing build results to <https://nixpkgs-unfree.cachix.org>. The
+The CI is pushing build results to <https://numtide.cachix.org>. The
 site provides instructions on adding the cache to your system.
 
 ### CUDA / performance packages
@@ -60,8 +60,8 @@ a separate instance:
   inputs.nixpkgs-unfree.inputs.nixpkgs.follows = "nixpkgs";
 
   # Optionally, pull pre-built binaries from this project's cache
-  nixConfig.extra-substituters = [ "https://nixpkgs-unfree.cachix.org" ];
-  nixConfig.extra-trusted-public-keys = [ "nixpkgs-unfree.cachix.org-1:hqvoInulhbV4nJ9yJOEr+4wxhDV4xq2d1DK7S6Nj6rs=" ];
+  nixConfig.extra-substituters = [ "https://numtide.cachix.org" ];
+  nixConfig.extra-trusted-public-keys = [ "numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE=" ];
 
   outputs = { self, nixpkgs, nixpkgs-unfree }: { ... };
 }

--- a/ci.nix
+++ b/ci.nix
@@ -1,7 +1,4 @@
 # Used by Hercules CI
 { system ? builtins.currentSystem }:
-{
-  "x86_64-linux" = (import ./. { system = "x86_64-linux"; }).checks // {
-    recurseForDerivations = true;
-  };
-}
+let flake = builtins.getFlake (toString ./.); in
+flake.checks.${system}

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 throw ''Some code is trying to create a new instance of nixpkgs.
-  Use `nixpkgs.legacyPackages.$${system}` instead.
+  Use `nixpkgs.legacyPackages.''${system}` instead.
 
   See https://zimbatm.com/notes/1000-instances-of-nixpkgs
 ''


### PR DESCRIPTION
also switching the binary cache due to how our runners are setup (pushing happens in the background).