### PR TITLE
Set builder job timeout to 1 week

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -7,8 +7,10 @@ on:
       - nixpkgs-unstable
   pull_request:
   workflow_dispatch:
+concurrency: "{{ github.head_ref ||  github.ref }}"
 jobs:
   build:
+    timeout-minutes: 10080
     strategy:
       matrix:
         system:


### PR DESCRIPTION
Sets the timeout of the build job to 1 week (might be overkill but better set it too high than too low) Also prevents multiple instances of the workflow from running concurrently.

Fix for #18 

(cc: @zimbatm)