### PR TITLE
checks: skip packages using requireFile

### DIFF
--- a/checks.nix
+++ b/checks.nix
@@ -55,8 +55,12 @@ let
 
   isNotCudaPackage = key: !(lib.hasPrefix "cuda" key);
 
+  canSubstituteSrc = pkg:
+    # requireFile don't allow using substituters and are therefor skipped
+    pkg.src.allowSubstitutes or true;
+
   select =
-    key: pkg: (isUnfree pkg) && (isSource key pkg) && (isNotCudaPackage key) && (isNotLinuxKernel key);
+    key: pkg: (isUnfree pkg) && (isSource key pkg) && (isNotCudaPackage key) && (isNotLinuxKernel key) && (canSubstituteSrc pkg);
 
   packages = packagesWith "" (key: select key) pkgs;
 in


### PR DESCRIPTION
Since `pkgs.requireFile` will always fail, it doesn't make sense to spend CPU resources on it.

This filter isn't 100% because some packages use requireFile on other inputs than the .src.